### PR TITLE
Fix event listener cleanup in header

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -24,7 +24,8 @@ const Header = () => {
   };
   useEffect(() => {
     window.addEventListener("scroll", handleStickyNavbar);
-  });
+    return () => window.removeEventListener("scroll", handleStickyNavbar);
+  }, []);
 
   // submenu handler
   const [openIndex, setOpenIndex] = useState(-1);


### PR DESCRIPTION
## Summary
- prevent multiple scroll event listeners in `Header` component

## Testing
- `npm install` *(fails: ENETUNREACH)*
- `npm run lint` *(fails: Next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888b02aa6188333982fa3d9d355ea9d