### PR TITLE
Fix alt text on blog-related images

### DIFF
--- a/src/app/blog-details/page.tsx
+++ b/src/app/blog-details/page.tsx
@@ -29,7 +29,7 @@ const BlogDetailsPage = () => {
                         <div className="relative h-10 w-10 overflow-hidden rounded-full">
                           <Image
                             src="/images/blog/author-02.png"
-                            alt="author"
+                            alt="Author Musharof Chy"
                             fill
                           />
                         </div>
@@ -112,7 +112,7 @@ const BlogDetailsPage = () => {
                     <div className="relative aspect-97/60 w-full sm:aspect-97/44">
                       <Image
                         src="/images/blog/blog-details-02.jpg"
-                        alt="image"
+                        alt="Team meeting"
                         fill
                         className="object-cover object-center"
                       />

--- a/src/app/blog-sidebar/page.tsx
+++ b/src/app/blog-sidebar/page.tsx
@@ -31,7 +31,7 @@ const BlogSidebarPage = () => {
                         <div className="relative h-10 w-10 overflow-hidden rounded-full">
                           <Image
                             src="/images/blog/author-02.png"
-                            alt="author"
+                            alt="Author Musharof Chy"
                             fill
                           />
                         </div>
@@ -114,7 +114,7 @@ const BlogSidebarPage = () => {
                     <div className="relative aspect-97/60 w-full sm:aspect-97/44">
                       <Image
                         src="/images/blog/blog-details-01.jpg"
-                        alt="image"
+                        alt="Office collaboration"
                         fill
                         className="h-full w-full object-cover object-center"
                       />

--- a/src/components/Blog/SingleBlog.tsx
+++ b/src/components/Blog/SingleBlog.tsx
@@ -14,7 +14,7 @@ const SingleBlog = ({ blog }: { blog: Blog }) => {
           <span className="bg-primary absolute top-6 right-6 z-20 inline-flex items-center justify-center rounded-full px-4 py-2 text-sm font-semibold text-white capitalize">
             {tags[0]}
           </span>
-          <Image src={image} alt="image" fill />
+          <Image src={image} alt={title} fill />
         </Link>
         <div className="p-6 sm:p-8 md:px-6 md:py-8 lg:p-8 xl:px-5 xl:py-8 2xl:p-8">
           <h3>
@@ -32,7 +32,7 @@ const SingleBlog = ({ blog }: { blog: Blog }) => {
             <div className="border-body-color/10 mr-5 flex items-center border-r pr-5 xl:mr-3 xl:pr-3 2xl:mr-5 2xl:pr-5 dark:border-white/10">
               <div className="mr-4">
                 <div className="relative h-10 w-10 overflow-hidden rounded-full">
-                  <Image src={author.image} alt="author" fill />
+                  <Image src={author.image} alt={`Author ${author.name}`} fill />
                 </div>
               </div>
               <div className="w-full">

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -13,14 +13,14 @@ const Footer = () => {
                 <Link href="/" className="mb-8 inline-block">
                   <Image
                     src="/images/logo/logo-2.svg"
-                    alt="logo"
+                    alt="Company logo"
                     className="w-full dark:hidden"
                     width={140}
                     height={30}
                   />
                   <Image
                     src="/images/logo/logo.png"
-                    alt="logo"
+                    alt="Company logo"
                     className="hidden dark:block"
                     width={30}
                     height={30}

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -59,14 +59,14 @@ const Header = () => {
               >
                 <Image
                   src="/images/logo/logo-2.svg"
-                  alt="logo"
+                  alt="Company logo"
                   width={30}
                   height={30}
                   className="w-full dark:hidden"
                 />
-                <Image 
+                <Image
                   src="/images/logo/logo.png"
-                  alt="logo"
+                  alt="Company logo"
                   width={30}
                   height={30}
                   className="hidden dark:block"


### PR DESCRIPTION
## Summary
- use blog titles and author names for dynamic `alt` text
- add descriptive captions to blog pages
- label header and footer logos as "Company logo"

## Testing
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6888b5c97bfc8333952a9f3bb6f4bcf6