### PR TITLE
Fix lint warnings and import typo

### DIFF
--- a/src/app/blog-details/page.tsx
+++ b/src/app/blog-details/page.tsx
@@ -289,7 +289,7 @@ const BlogDetailsPage = () => {
                     </span>
                   </div>
                   <p className="text-body-color mb-10 text-base leading-relaxed font-medium sm:text-lg sm:leading-relaxed lg:text-base lg:leading-relaxed xl:text-lg xl:leading-relaxed">
-                    For more articles like this, follow the blog and reach out if you'd like to collaborate on a project.
+                    For more articles like this, follow the blog and reach out if you&apos;d like to collaborate on a project.
                   </p>
                   <div className="items-center justify-between sm:flex">
                     <div className="mb-5">

--- a/src/app/blog-sidebar/page.tsx
+++ b/src/app/blog-sidebar/page.tsx
@@ -291,7 +291,7 @@ const BlogSidebarPage = () => {
                     </span>
                   </div>
                   <p className="text-body-color mb-10 text-base leading-relaxed font-medium sm:text-lg sm:leading-relaxed lg:text-base lg:leading-relaxed xl:text-lg xl:leading-relaxed">
-                    For more articles like this, follow the blog and reach out if you'd like to collaborate on a project.
+                    For more articles like this, follow the blog and reach out if you&apos;d like to collaborate on a project.
                   </p>
                   <div className="items-center justify-between sm:flex">
                     <div className="mb-5">

--- a/src/components/Contact/index.tsx
+++ b/src/components/Contact/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import NewsLatterBox from "./NewsLatterBox";
+import NewsletterBox from "./NewsletterBox";
 
 type FormState = {
   name: string;


### PR DESCRIPTION
## Summary
- escape apostrophes in blog pages to satisfy eslint
- correct NewsletterBox import typo

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888c2381bd88333a110f856619efbf1