### PR TITLE
Fix optional imageLight type usage

### DIFF
--- a/src/components/Brands/index.tsx
+++ b/src/components/Brands/index.tsx
@@ -33,7 +33,14 @@ const SingleBrand = ({ brand }: { brand: Brand }) => {
         rel="nofollow noreferrer"
         className="relative h-10 w-full opacity-70 transition hover:opacity-100 dark:opacity-60 dark:hover:opacity-100"
       >
-        <Image src={imageLight} alt={name} fill className="hidden dark:block" />
+        {imageLight && (
+          <Image
+            src={imageLight}
+            alt={name}
+            fill
+            className="hidden dark:block"
+          />
+        )}
         <Image src={image} alt={name} fill className="block dark:hidden" />
       </a>
     </div>


### PR DESCRIPTION
## Summary
- handle `Brand.imageLight` being optional before rendering the image

## Testing
- `npm install` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6888c46588548333830acdeebbb449e6