### PR TITLE
Fix submenu link type error

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -146,7 +146,7 @@ const Header = () => {
                             >
                               {menuItem.submenu?.map((submenuItem, index) => (
                                 <Link
-                                  href={submenuItem.path}
+                                  href={submenuItem.path ?? "#"}
                                   key={index}
                                   className="text-dark hover:text-primary block rounded-sm py-2.5 text-sm lg:px-3 dark:text-white/70 dark:hover:text-white"
                                 >


### PR DESCRIPTION
## Summary
- ensure submenu `Link` component always receives a defined `href`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888d045f79883338e9aab87de66eb6d